### PR TITLE
feat: Add info about reward that user get

### DIFF
--- a/src/engine/Core.java
+++ b/src/engine/Core.java
@@ -20,7 +20,7 @@ public final class Core {
 	/** Height of current screen. */
 	private static final int HEIGHT = 780;
 	/** Max fps of current screen. */
-	private static final int FPS = 160;
+	private static final int FPS = 90;
 
 	/** Max lives. */
 	private static final int MAX_LIVES = 3;

--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -723,11 +723,11 @@ public final class DrawManager {
 				rectWidth, rectHeight);
 		backBufferGraphics.setColor(Color.GREEN);
 		if (number >= 4)
-			if (!bonusLife && level != 2) {
+			if (!bonusLife && level != 4) {
 				drawCenteredBigString(screen, "Level " + level,
 						screen.getHeight() / 2
 						+ fontBigMetrics.getHeight() / 3);
-			} else if (!bonusLife && level == 2) {
+			} else if (!bonusLife && level == 4) {
 				drawCenteredBigString(screen, "Level " + level
 								+ " - Ship Changed!",
 						screen.getHeight() / 2
@@ -745,4 +745,11 @@ public final class DrawManager {
 			drawCenteredBigString(screen, "GO!", screen.getHeight() / 2
 					+ fontBigMetrics.getHeight() / 3);
 	}
+
+	public void drawGetItem(final Screen screen, String rewardInfo) {
+		backBufferGraphics.setColor(Color.GREEN);
+		drawCenteredRegularString(screen, rewardInfo, 25);
+	}
+
+
 }


### PR DESCRIPTION
유저가 리워드 획득시 화면에 표시되도록 변경
INVADER-40

## Pull request checklist

**Please check if your PR meets the following requirements**

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Build tested with (`Run Java`) and no errors

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring
- [ ] Documentation
- [ ] Other (describe):

## Describe your Pull Request


![KakaoTalk_Photo_2021-12-08-13-58-56](https://user-images.githubusercontent.com/68222629/145150888-83177c96-242a-449b-8e37-8e86ebcbbb5b.png)
- 유저가 스페셜쉽에서 얻은 보상을 획득 시 가운데 상단에 표시되도록 하였습니다.

![KakaoTalk_Photo_2021-12-08-13-58-46](https://user-images.githubusercontent.com/68222629/145150928-00f9a172-73bd-4e18-9ac2-2ca5c9bcbf89.png)
- 스테이지 클리어 보상은 꽝이 등장하지 않도록 수정했습니다.
- 위와 마찬가지로 가운데 상단에 표시되도록 했습니다.

- 게임 속도를 기존의 `1.5배`로 조정하였습니다.
- 기체 변경 리워드를 `4단계` 시작하는 시점으로 변경했습니다.
- 이렇게 해서 단계별 리워드는
  - 매 라운드: 랜덤리워드 (속도 증가 등)
  - 3, 6라운드: 생명+1 (기존에 있던 기능)
  - 4라운드: 기체 외형 업그레이드
- 로 마무리 지으면 될 것 같습니다!

